### PR TITLE
fix: properly export Supabase client

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -31,12 +31,8 @@ export function getSupabase() {
   return supabaseInstance;
 }
 
-// Export singleton getter
-export const supabase = {
-  get client() {
-    return getSupabase();
-  },
-};
+// Create and export the singleton Supabase client
+export const supabase = getSupabase();
 
 /**
  * Test database connection
@@ -44,7 +40,7 @@ export const supabase = {
  */
 export async function testConnection() {
   try {
-    const { error } = await getSupabase()
+    const { error } = await supabase
       .from('temp_vcs')
       .select('count')
       .limit(1);
@@ -65,7 +61,7 @@ export const tempVCDB = {
    */
   async create(channelId, ownerId, guildId) {
     try {
-      const { error } = await getSupabase()
+      const { error } = await supabase
         .from('temp_vcs')
         .insert({
           channel_id: channelId,
@@ -91,7 +87,7 @@ export const tempVCDB = {
    */
   async updateLastActive(channelId) {
     try {
-      const { error } = await getSupabase()
+      const { error } = await supabase
         .from('temp_vcs')
         .update({ last_active: new Date().toISOString() })
         .eq('channel_id', channelId);


### PR DESCRIPTION
## Summary
- export a singleton Supabase client instead of a wrapper object
- update helper functions to use the exported client directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba00f333d0832d8082d978479d5110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Refactor
  - Streamlined database client to a single, eagerly initialized instance used across the app for more consistent behavior and reduced overhead.

- Chores
  - Updated all call sites to use the new client export for consistency and less boilerplate.
  - Adjusted initialization logging to occur at import time for clearer startup visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->