### PR TITLE
feat: nightly janitor for invites and VC guards

### DIFF
--- a/src/commands/generate-invite.js
+++ b/src/commands/generate-invite.js
@@ -137,7 +137,7 @@ export async function execute(interaction) {
   
   const maxAgeSeconds = expireDays > 0 ? expireDays * 24 * 60 * 60 : 0;
 
-  await interaction.deferReply({ ephemeral: true });
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
   try {
     // Create Discord invite
@@ -148,6 +148,8 @@ export async function execute(interaction) {
       unique: true,
       reason: `${roleName} invite created by ${interaction.user.tag}`,
     });
+
+    console.log(`Invite created: ${invite.code} (discord maxUses=${invite.maxUses}, maxAge=${invite.maxAge})`);
 
     let expiresAt = null;
     if (maxAgeSeconds > 0) {

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -4,6 +4,7 @@ import { config } from '../config.js';
 import { getAllCommandData } from '../commands/index.js';
 import { initTempVCService, sweepTempRooms } from '../services/temp-vc-service.js';
 import { initInviteRoleService } from '../services/invite-role-service.js';
+import { scheduleNightly, pruneRoleInvites } from '../services/janitor.js';
 import { ensureDecreeExists } from '../services/oath-service.js';
 
 export const name = Events.ClientReady;
@@ -96,6 +97,14 @@ export async function execute(client) {
     } catch (cleanupError) {
       console.error('Error setting up periodic cleanup:', cleanupError);
       console.warn('Periodic cleanup disabled - manual cleanup may be required');
+    }
+
+    // Nightly janitor tasks
+    try {
+      scheduleNightly(client, [pruneRoleInvites]);
+      console.log('Nightly janitor scheduled');
+    } catch (janitorError) {
+      console.error('Error scheduling nightly janitor:', janitorError);
     }
 
     console.log('Bot fully initialized and ready!');

--- a/src/services/janitor.js
+++ b/src/services/janitor.js
@@ -1,0 +1,61 @@
+// src/services/janitor.js
+import { InviteDB } from '../database/invites.js';
+import { supabase } from '../db.js';
+
+const NIGHTLY_HOUR_UTC = 3;
+
+export function scheduleNightly(client, jobs = []) {
+  const now = new Date();
+  const first = new Date(now);
+  first.setUTCHours(NIGHTLY_HOUR_UTC, 0, 0, 0);
+  if (first <= now) {
+    first.setUTCDate(first.getUTCDate() + 1);
+  }
+
+  const runJobs = async () => {
+    for (const job of jobs) {
+      try {
+        await job(client);
+      } catch (err) {
+        console.error('[Janitor] job failed:', err);
+      }
+    }
+  };
+
+  setTimeout(() => {
+    runJobs();
+    setInterval(runJobs, 24 * 60 * 60 * 1000);
+  }, first - now);
+}
+
+export async function pruneRoleInvites() {
+  try {
+    console.log('[Janitor] Starting invite prune');
+
+    const expired = await InviteDB.cleanupExpiredInvites();
+    if (expired.ok && expired.data.cleanedCount > 0) {
+      console.log(`[Janitor] Removed ${expired.data.cleanedCount} expired invite mappings`);
+    }
+
+    const { data, error } = await supabase
+      .from('invite_mappings')
+      .select('invite_code, max_uses, current_uses')
+      .gt('max_uses', 0);
+
+    if (error) {
+      console.error('[Janitor] Error fetching invites for exhaustion check:', error);
+    } else {
+      const toRemove = (data || [])
+        .filter(row => row.max_uses > 0 && row.current_uses >= row.max_uses)
+        .map(row => row.invite_code);
+      if (toRemove.length) {
+        await InviteDB.removeInviteMappings(toRemove);
+        console.log(`[Janitor] Removed ${toRemove.length} exhausted invite mappings`);
+      }
+    }
+
+    console.log('[Janitor] Invite prune complete');
+  } catch (err) {
+    console.error('[Janitor] pruneRoleInvites failed:', err);
+  }
+}

--- a/src/services/temp-vc-service.js
+++ b/src/services/temp-vc-service.js
@@ -8,14 +8,21 @@ import { supabase } from '../db.js';
 export const tempOwners = new Map(); // channelId -> ownerId
 
 let client = null;
+let _tempVCServiceInit = false;
 
 export async function initTempVCService(discordClient) {
+  if (_tempVCServiceInit) {
+    console.warn('initTempVCService called more than once; ignoring.');
+    return;
+  }
+  _tempVCServiceInit = true;
+
   try {
     client = discordClient;
-    
+
     // Load existing temp VCs from database on startup
     await loadTempVCsFromDatabase();
-    
+
     console.log('Temp VC service initialized successfully');
     return { ok: true };
   } catch (error) {


### PR DESCRIPTION
## Summary
- guard temp VC and invite-role service init to prevent double listeners
- add nightly janitor to prune expired or exhausted invite mappings
- auto-delete empty temp voice channels immediately and fix invite generation flags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5df5ded4832db3121168b83e0921

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly maintenance now runs automatically to clean up expired/used invites, improving invite accuracy.
  * Temporary voice channels are automatically deleted when empty, keeping servers tidy.
  * Invite generation replies are now ephemeral for a cleaner user experience.

* **Chores**
  * Added a background janitor service and scheduled it on startup.
  * Improved service initialization to prevent duplicate setup for greater stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->